### PR TITLE
Fix ClassString production in CompileToCharSet

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36317,7 +36317,8 @@ THH:mm:ss.sss
         <!-- ClassStringDisjunctionContents -->
         <emu-grammar>ClassStringDisjunctionContents :: ClassString</emu-grammar>
         <emu-alg>
-          1. Return CompileToCharSet of |ClassString|.
+          1. Let _s_ be CompileClassSetString of |ClassString|.
+          1. Return the CharSet containing the one string _s_.
         </emu-alg>
         <emu-grammar>ClassStringDisjunctionContents :: ClassString `|` ClassStringDisjunctionContents</emu-grammar>
         <emu-alg>


### PR DESCRIPTION
Add rules to production ClassStringDisjunctionContents :: ClassString in CompileToCharSet.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
